### PR TITLE
chore: Add github copilot setup workflow with pixi

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,38 @@
+name: "Copilot Setup Steps"
+
+# Automatically run the setup steps when they are changed to allow for easy validation, and
+# allow manual testing through the repository's "Actions" tab
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    # Set the permissions to the lowest permissions possible needed for your steps.
+    # Copilot will be given its own token for its operations.
+    permissions:
+      # If you want to clone the repository as part of your setup steps, for example to install dependencies, you'll need the `contents: read` permission. If you don't clone the repository in your setup steps, Copilot will do this for you automatically after the steps complete.
+      contents: read
+
+    # You can define any steps you want, and they will run before the agent starts.
+    # If you do not check out your code, Copilot will do this for you.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.9.1
+        with:
+          pixi-version: v0.56.0
+          cache: true
+
+      - name: Print pixi info
+        run: pixi info


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for Copilot setup. The workflow automates the validation of setup steps when changes are made and allows for manual testing via the Actions tab. It ensures the environment is prepared with the necessary tools before Copilot runs.

New Copilot setup workflow:

* Added `.github/workflows/copilot-setup-steps.yml` to define a reusable workflow that:
  - Runs on workflow dispatch, push, or pull request events targeting the workflow file.
  - Checks out the repository code.
  - Sets up the `pixi` tool using `prefix-dev/setup-pixi@v0.9.1` with caching enabled.
  - Prints `pixi` environment information for validation.