### PR TITLE
fix: Fix double activation of pixi env

### DIFF
--- a/.devcontainer/onCreate.sh
+++ b/.devcontainer/onCreate.sh
@@ -5,4 +5,3 @@ set -e
 
 sudo chown vscode .pixi
 pixi install --all
-pixi shell-hook >> ${VSCODE_HOME}/.bashrc


### PR DESCRIPTION
This pull request makes a minor update to the `.devcontainer/onCreate.sh` script by removing the line that appended the `pixi shell-hook` to the `.bashrc` file.