### PR TITLE
Feat/fits header grouping

### DIFF
--- a/src/ovro_lwa_portal/fits_to_zarr_xradio.py
+++ b/src/ovro_lwa_portal/fits_to_zarr_xradio.py
@@ -40,8 +40,8 @@ Library usage
 
 Notes
 -----
-* The code assumes filenames of the form:
-  YYYYMMDD_HHMMSS_<SB>MHz_averaged_* -I-image[ _fixed].fits
+* Discovery groups files by observation time/frequency from FITS headers first.
+  Filename parsing is only used as a fallback when header metadata is missing.
 * LM grids must match across time steps; a mismatch raises a RuntimeError.
 * On append, the existing Zarr is read and re-written with the appended time step.
 """

--- a/src/ovro_lwa_portal/fits_to_zarr_xradio.py
+++ b/src/ovro_lwa_portal/fits_to_zarr_xradio.py
@@ -190,6 +190,14 @@ def _extract_group_metadata(fp: Path) -> Tuple[Optional[str], Optional[float], L
     return time_key, frequency_hz, notes
 
 
+def _frequency_sort_tuple(fp: Path) -> Tuple[float, str]:
+    """Sort key for deterministic frequency ordering with fallback."""
+    _, frequency_hz, _ = _extract_group_metadata(fp)
+    if frequency_hz is None:
+        return (float(10**15), fp.name)
+    return (float(frequency_hz), fp.name)
+
+
 def _fix_headers(path_in: Path, path_out: Path) -> None:
     """Write a *_fixed.fits with BSCALE/BZERO applied and minimal WCS/spectral keys.
 
@@ -266,7 +274,7 @@ def _get_fixed_paths(files: List[Path], fixed_dir: Path) -> List[Path]:
         List of paths to fixed FITS files, sorted by frequency.
     """
     fixed_paths: List[Path] = []
-    for f in sorted(files, key=_mhz_from_name):
+    for f in sorted(files, key=_frequency_sort_tuple):
         if f.name.endswith("_fixed.fits"):
             fixed_paths.append(f)
         else:
@@ -323,7 +331,7 @@ def fix_fits_headers(
     fixed_dir.mkdir(parents=True, exist_ok=True)
     fixed_paths: List[Path] = []
 
-    for f in sorted(files, key=_mhz_from_name):
+    for f in sorted(files, key=_frequency_sort_tuple):
         if f.name.endswith("_fixed.fits"):
             # Already fixed, use as-is
             fixed_paths.append(f)
@@ -502,6 +510,9 @@ def _discover_groups(
         if notes:
             logger.warning(f"Using fallback metadata for {f.name}: {', '.join(notes)}")
         by_time.setdefault(time_key, []).append(f)
+
+    for time_key, files in by_time.items():
+        by_time[time_key] = sorted(files, key=_frequency_sort_tuple)
     return by_time
 
 
@@ -708,8 +719,8 @@ def convert_fits_dir_to_zarr(
     total_files = sum(len(v) for v in by_time.values())
     logger.info(f"Discovered {total_files} FITS across {len(by_time)} time step(s).")
     for k, v in by_time.items():
-        mhz_sorted = sorted(_mhz_from_name(p) for p in v)
-        logger.info(f"  time {k}: {len(v)} file(s), subbands (MHz): {mhz_sorted}")
+        freqs_hz = [_extract_group_metadata(p)[1] for p in v]
+        logger.info(f"  time {k}: {len(v)} file(s), frequencies (Hz): {freqs_hz}")
 
     if not by_time:
         raise FileNotFoundError(f"No matching FITS found in {input_dir}")

--- a/src/ovro_lwa_portal/fits_to_zarr_xradio.py
+++ b/src/ovro_lwa_portal/fits_to_zarr_xradio.py
@@ -498,6 +498,11 @@ def _discover_groups(
             by_time.setdefault(time_key, [])
             by_time[time_key] = [p for p in by_time[time_key] if p not in candidates]
             by_time[time_key].append(selected)
+            # Replace the pending duplicate bucket so the next file with this (time, freq)
+            # starts from the chosen file only. Otherwise `candidates` never shrinks and
+            # grows as [f1, f2, f3, ...], re-invoking the resolver with stale paths and
+            # widening the filter that strips `by_time[time_key]`.
+            time_freq_map[freq_key] = [selected]
             logger.warning(
                 "Duplicate FITS files for time=%s, frequency_hz=%.1f. Selected: %s. Candidates: %s",
                 time_key,

--- a/src/ovro_lwa_portal/fits_to_zarr_xradio.py
+++ b/src/ovro_lwa_portal/fits_to_zarr_xradio.py
@@ -56,6 +56,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 import numpy as np
 import xarray as xr
 from astropy.io import fits
+from astropy.time import Time
 from astropy.wcs import WCS
 from numpy.typing import NDArray
 from xradio.image import read_image, write_image
@@ -69,6 +70,14 @@ PAT = re.compile(
     r"^(?P<date>\d{8})_(?P<hms>\d{6})_(?P<sb>\d+)MHz_averaged_.*-I-image(?:_fixed)?\.fits$"
 )
 MHZ_RE = re.compile(r"_(\d+)MHz_")
+
+
+def _time_key_from_name(p: Path) -> Optional[str]:
+    """Extract a normalized ``YYYYMMDD_HHMMSS`` key from filename when possible."""
+    m = PAT.match(p.name)
+    if not m:
+        return None
+    return f"{m.group('date')}_{m.group('hms')}"
 
 
 def _mhz_from_name(p: Path) -> int:
@@ -86,6 +95,99 @@ def _mhz_from_name(p: Path) -> int:
     """
     m = MHZ_RE.search(p.name)
     return int(m.group(1)) if m else 10**9
+
+
+def _time_key_from_header(header: fits.Header) -> Optional[str]:
+    """Extract observation time from FITS headers as ``YYYYMMDD_HHMMSS``.
+
+    Header precedence:
+      1) ``DATE-OBS`` (optionally with ``TIME-OBS`` if date-only)
+      2) ``MJD-OBS``
+      3) ``MJD``
+
+    Returns ``None`` when no usable timestamp is found.
+    """
+    date_obs = header.get("DATE-OBS")
+    if date_obs:
+        date_obs = str(date_obs).strip()
+        time_obs = header.get("TIME-OBS")
+        if time_obs and "T" not in date_obs:
+            dt_value = f"{date_obs}T{str(time_obs).strip()}"
+        else:
+            dt_value = date_obs
+        try:
+            t = Time(dt_value, format="isot", scale="utc")
+            return t.to_datetime().strftime("%Y%m%d_%H%M%S")
+        except Exception:
+            logger.debug(f"Could not parse DATE-OBS/TIME-OBS timestamp: {dt_value}")
+
+    for mjd_key in ("MJD-OBS", "MJD"):
+        if mjd_key in header:
+            try:
+                t = Time(float(header[mjd_key]), format="mjd", scale="utc")
+                return t.to_datetime().strftime("%Y%m%d_%H%M%S")
+            except Exception:
+                logger.debug(f"Could not parse {mjd_key} timestamp: {header.get(mjd_key)}")
+
+    return None
+
+
+def _frequency_hz_from_header(header: fits.Header) -> Optional[float]:
+    """Extract frequency in Hz from FITS headers.
+
+    Header precedence:
+      1) ``RESTFREQ``
+      2) ``RESTFRQ``
+      3) ``CRVAL3``
+      4) ``FREQ``
+    """
+    for key in ("RESTFREQ", "RESTFRQ", "CRVAL3", "FREQ"):
+        value = header.get(key)
+        if value is None:
+            continue
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            logger.debug(f"Could not parse {key} frequency: {value}")
+    return None
+
+
+def _extract_group_metadata(fp: Path) -> Tuple[Optional[str], Optional[float], List[str]]:
+    """Extract grouping metadata from headers with filename fallback.
+
+    Returns
+    -------
+    Tuple[Optional[str], Optional[float], List[str]]
+        Tuple of ``(time_key, frequency_hz, fallback_notes)`` where fallback_notes
+        records when filename-based fallback was used.
+    """
+    time_key: Optional[str] = None
+    frequency_hz: Optional[float] = None
+    notes: List[str] = []
+
+    header: Optional[fits.Header] = None
+    try:
+        header = fits.getheader(fp, ext=0)
+    except Exception as e:
+        logger.warning(f"Could not read FITS header for {fp.name}: {e}")
+
+    if header is not None:
+        time_key = _time_key_from_header(header)
+        frequency_hz = _frequency_hz_from_header(header)
+
+    if time_key is None:
+        name_time_key = _time_key_from_name(fp)
+        if name_time_key is not None:
+            time_key = name_time_key
+            notes.append("time-from-filename")
+
+    if frequency_hz is None:
+        mhz = _mhz_from_name(fp)
+        if mhz != 10**9:
+            frequency_hz = float(mhz * 1e6)
+            notes.append("frequency-from-filename")
+
+    return time_key, frequency_hz, notes
 
 
 def _fix_headers(path_in: Path, path_out: Path) -> None:
@@ -330,7 +432,10 @@ def _load_for_combine(fp: Path, *, chunk_lm: int = 1024) -> xr.Dataset:
     return xds
 
 
-def _discover_groups(in_dir: Path) -> Dict[str, List[Path]]:
+def _discover_groups(
+    in_dir: Path,
+    duplicate_resolver: Optional[Callable[[str, float, List[Path]], Path]] = None,
+) -> Dict[str, List[Path]]:
     """Group input FITS by time key 'YYYYMMDD_HHMMSS' using PAT.
 
     Parameters
@@ -344,12 +449,59 @@ def _discover_groups(in_dir: Path) -> Dict[str, List[Path]]:
         Dictionary mapping time keys to lists of FITS file paths.
     """
     by_time: Dict[str, List[Path]] = {}
+    by_time_freq: Dict[str, Dict[int, List[Path]]] = {}
     for f in sorted(in_dir.glob("*.fits")):
-        m = PAT.match(f.name)
-        if not m:
+        time_key, frequency_hz, notes = _extract_group_metadata(f)
+        if time_key is None:
+            logger.warning(
+                f"Skipping {f.name}: missing usable observation time in FITS headers and filename."
+            )
             continue
-        key = f"{m.group('date')}_{m.group('hms')}"
-        by_time.setdefault(key, []).append(f)
+        if frequency_hz is None:
+            logger.warning(
+                f"Could not determine frequency for {f.name}; duplicate detection disabled for this file."
+            )
+            by_time.setdefault(time_key, []).append(f)
+            continue
+
+        freq_key = int(round(frequency_hz))
+        time_freq_map = by_time_freq.setdefault(time_key, {})
+        candidates = time_freq_map.setdefault(freq_key, [])
+        candidates.append(f)
+
+        if len(candidates) > 1:
+            duplicate_names = [p.name for p in candidates]
+            if duplicate_resolver is None:
+                msg = (
+                    "Duplicate FITS files detected for the same time/frequency group "
+                    f"(time={time_key}, frequency_hz={float(freq_key)}): {duplicate_names}. "
+                    "Provide unique inputs or pass duplicate_resolver to choose one."
+                )
+                raise RuntimeError(msg)
+
+            selected = duplicate_resolver(time_key, float(freq_key), candidates.copy())
+            if selected not in candidates:
+                msg = (
+                    f"Duplicate resolver returned unknown file {selected} for "
+                    f"time={time_key}, frequency_hz={float(freq_key)}."
+                )
+                raise RuntimeError(msg)
+
+            by_time.setdefault(time_key, [])
+            by_time[time_key] = [p for p in by_time[time_key] if p not in candidates]
+            by_time[time_key].append(selected)
+            logger.warning(
+                "Duplicate FITS files for time=%s, frequency_hz=%.1f. Selected: %s. Candidates: %s",
+                time_key,
+                float(freq_key),
+                selected.name,
+                duplicate_names,
+            )
+            continue
+
+        if notes:
+            logger.warning(f"Using fallback metadata for {f.name}: {', '.join(notes)}")
+        by_time.setdefault(time_key, []).append(f)
     return by_time
 
 
@@ -504,6 +656,7 @@ def convert_fits_dir_to_zarr(
     rebuild: bool = False,
     fix_headers_on_demand: bool = True,
     progress_callback: Optional[Callable[[str, int, int, str], None]] = None,
+    duplicate_resolver: Optional[Callable[[str, float, List[Path]], Path]] = None,
 ) -> Path:
     """Convert all matching FITS in a directory into a single LM-only Zarr store.
 
@@ -528,6 +681,9 @@ def convert_fits_dir_to_zarr(
     progress_callback
         Optional callback function for progress reporting. Should accept
         (stage: str, current: int, total: int, message: str).
+    duplicate_resolver
+        Optional callback to resolve duplicate files that map to the same
+        time/frequency group. Signature: ``(time_key, frequency_hz, candidates) -> selected_path``.
 
     Returns
     -------
@@ -548,7 +704,7 @@ def convert_fits_dir_to_zarr(
     fixed_dir.mkdir(parents=True, exist_ok=True)
     out_zarr = out_dir / zarr_name
 
-    by_time = _discover_groups(input_dir)
+    by_time = _discover_groups(input_dir, duplicate_resolver=duplicate_resolver)
     total_files = sum(len(v) for v in by_time.values())
     logger.info(f"Discovered {total_files} FITS across {len(by_time)} time step(s).")
     for k, v in by_time.items():

--- a/src/ovro_lwa_portal/ingest/cli.py
+++ b/src/ovro_lwa_portal/ingest/cli.py
@@ -155,7 +155,8 @@ def convert(
 
     This command processes FITS image files from the specified INPUT_DIR and
     combines them into an optimized Zarr store at OUTPUT_DIR. Files are grouped
-    by observation time and frequency subband.
+    by observation time and frequency, using FITS headers first with filename
+    parsing as a fallback when headers are incomplete.
 
     \b
     Examples:
@@ -280,7 +281,8 @@ def convert(
             console.print(
                 "\nNo matching FITS files found. Please check:\n"
                 "  • The input directory contains FITS files\n"
-                "  • Files follow the naming pattern: YYYYMMDD_HHMMSS_*MHz_*-I-image.fits"
+                "  • FITS headers contain usable observation time/frequency metadata\n"
+                "  • Or filenames include parseable fallback patterns (e.g., YYYYMMDD_HHMMSS_*MHz_*)"
             )
             raise typer.Exit(code=1) from e
 

--- a/src/ovro_lwa_portal/ingest/cli.py
+++ b/src/ovro_lwa_portal/ingest/cli.py
@@ -24,6 +24,7 @@ from rich.progress import (
     TextColumn,
     TimeElapsedColumn,
 )
+from rich.prompt import Prompt
 
 from ovro_lwa_portal.fits_to_zarr_xradio import fix_fits_headers
 from ovro_lwa_portal.ingest.core import ConversionConfig, FITSToZarrConverter
@@ -178,6 +179,24 @@ def convert(
     verbose = log_level == LogLevel.DEBUG
 
     # Build configuration
+    def duplicate_resolver(time_key: str, frequency_hz: float, candidates: list[Path]) -> Path:
+        """Prompt user to resolve duplicate files in the same time/subband."""
+        console.print(
+            "\n[bold yellow]Duplicate FITS candidates detected[/bold yellow] "
+            f"for time={time_key}, frequency={frequency_hz:.1f} Hz"
+        )
+        for idx, candidate in enumerate(candidates, start=1):
+            console.print(f"  {idx}. {candidate}")
+
+        choices = [str(i) for i in range(1, len(candidates) + 1)]
+        selection = Prompt.ask(
+            "Select which file to use",
+            choices=choices,
+            default="1",
+            console=console,
+        )
+        return candidates[int(selection) - 1]
+
     config = ConversionConfig(
         input_dir=input_dir,
         output_dir=output_dir,
@@ -186,6 +205,7 @@ def convert(
         chunk_lm=chunk_lm,
         rebuild=rebuild,
         fix_headers_on_demand=not skip_header_fixing,  # Invert the flag
+        duplicate_resolver=duplicate_resolver,
         verbose=verbose,
     )
 

--- a/src/ovro_lwa_portal/ingest/cli.py
+++ b/src/ovro_lwa_portal/ingest/cli.py
@@ -179,24 +179,6 @@ def convert(
     verbose = log_level == LogLevel.DEBUG
 
     # Build configuration
-    def duplicate_resolver(time_key: str, frequency_hz: float, candidates: list[Path]) -> Path:
-        """Prompt user to resolve duplicate files in the same time/subband."""
-        console.print(
-            "\n[bold yellow]Duplicate FITS candidates detected[/bold yellow] "
-            f"for time={time_key}, frequency={frequency_hz:.1f} Hz"
-        )
-        for idx, candidate in enumerate(candidates, start=1):
-            console.print(f"  {idx}. {candidate}")
-
-        choices = [str(i) for i in range(1, len(candidates) + 1)]
-        selection = Prompt.ask(
-            "Select which file to use",
-            choices=choices,
-            default="1",
-            console=console,
-        )
-        return candidates[int(selection) - 1]
-
     config = ConversionConfig(
         input_dir=input_dir,
         output_dir=output_dir,
@@ -205,7 +187,7 @@ def convert(
         chunk_lm=chunk_lm,
         rebuild=rebuild,
         fix_headers_on_demand=not skip_header_fixing,  # Invert the flag
-        duplicate_resolver=duplicate_resolver,
+        duplicate_resolver=None,
         verbose=verbose,
     )
 
@@ -245,13 +227,42 @@ def convert(
     ) as progress:
         task = progress.add_task("Converting...", total=100)
 
+        duplicate_prompt_context = {"active": False}
+
         def progress_callback(stage: str, current: int, total: int, message: str) -> None:
             """Update progress bar based on conversion stage."""
+            if duplicate_prompt_context["active"]:
+                return
             if total > 0:
                 percentage = (current / total) * 100
                 progress.update(task, completed=percentage, description=message)
 
+        def duplicate_resolver(time_key: str, frequency_hz: float, candidates: list[Path]) -> Path:
+            """Prompt user to resolve duplicate files in the same time/subband."""
+            duplicate_prompt_context["active"] = True
+            progress.stop()
+            try:
+                console.print(
+                    "\n[bold yellow]Duplicate FITS candidates detected[/bold yellow] "
+                    f"for time={time_key}, frequency={frequency_hz:.1f} Hz"
+                )
+                for idx, candidate in enumerate(candidates, start=1):
+                    console.print(f"  {idx}. {candidate}")
+
+                choices = [str(i) for i in range(1, len(candidates) + 1)]
+                selection = Prompt.ask(
+                    "Select which file to use",
+                    choices=choices,
+                    default="1",
+                    console=console,
+                )
+                return candidates[int(selection) - 1]
+            finally:
+                progress.start()
+                duplicate_prompt_context["active"] = False
+
         # Execute conversion (suppress CASA stderr warnings unless in debug mode)
+        config.duplicate_resolver = duplicate_resolver
         converter = FITSToZarrConverter(config, progress_callback=progress_callback)
 
         try:

--- a/src/ovro_lwa_portal/ingest/core.py
+++ b/src/ovro_lwa_portal/ingest/core.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Callable, Protocol
 
 import portalocker
 
@@ -74,6 +74,7 @@ class ConversionConfig:
         chunk_lm: int = 1024,
         rebuild: bool = False,
         fix_headers_on_demand: bool = True,
+        duplicate_resolver: Callable[[str, float, list[Path]], Path] | None = None,
         verbose: bool = False,
     ) -> None:
         self.input_dir = input_dir
@@ -83,6 +84,7 @@ class ConversionConfig:
         self.chunk_lm = chunk_lm
         self.rebuild = rebuild
         self.fix_headers_on_demand = fix_headers_on_demand
+        self.duplicate_resolver = duplicate_resolver
         self.verbose = verbose
 
     @property
@@ -225,6 +227,7 @@ class FITSToZarrConverter:
                     rebuild=self.config.rebuild,
                     fix_headers_on_demand=self.config.fix_headers_on_demand,
                     progress_callback=self.progress_callback,
+                    duplicate_resolver=self.config.duplicate_resolver,
                 )
 
                 self._report_progress("complete", 1, 1, "Conversion complete")

--- a/src/ovro_lwa_portal/ingest/prefect_workflow.py
+++ b/src/ovro_lwa_portal/ingest/prefect_workflow.py
@@ -12,8 +12,9 @@ To use this module, install the 'prefect' optional dependency:
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NoReturn
 
 if TYPE_CHECKING:
     from ovro_lwa_portal.ingest.core import ConversionConfig
@@ -29,7 +30,7 @@ try:
 except ImportError:
     PREFECT_AVAILABLE = False
 
-    def _raise_import_error() -> None:
+    def _raise_import_error() -> NoReturn:
         msg = (
             "Prefect is not installed. Install it with:\n"
             "  pip install ovro_lwa_portal[prefect]\n"
@@ -59,6 +60,20 @@ except ImportError:
             return decorator(func)
         return decorator
 if PREFECT_AVAILABLE:
+    _DUP_FITS_ERR = "Duplicate FITS files detected"
+
+    def _execute_conversion_should_retry(
+        _task: object, _task_run: object, state: object
+    ) -> bool:
+        """Return False for duplicate-FITS RuntimeErrors: retries will not help."""
+        try:
+            state.result()  # type: ignore[union-attr]
+        except RuntimeError as exc:
+            if _DUP_FITS_ERR in str(exc):
+                return False
+        except Exception:
+            pass
+        return True
 
     @task(name="Validate Configuration")
     def validate_config_task(config: ConversionConfig) -> None:
@@ -97,7 +112,12 @@ if PREFECT_AVAILABLE:
         logger.info(f"Output directory: {config.output_dir}")
         logger.info(f"Fixed FITS directory: {config.fixed_dir}")
 
-    @task(name="Execute Conversion", retries=2, retry_delay_seconds=60)
+    @task(
+        name="Execute Conversion",
+        retries=2,
+        retry_delay_seconds=60,
+        retry_condition_fn=_execute_conversion_should_retry,
+    )
     def execute_conversion_task(config: ConversionConfig) -> Path:
         """Execute the FITS to Zarr conversion as a Prefect task.
 
@@ -137,6 +157,7 @@ if PREFECT_AVAILABLE:
         fixed_dir: str | Path | None = None,
         chunk_lm: int = 1024,
         rebuild: bool = False,
+        duplicate_resolver: Callable[[str, float, list[Path]], Path] | None = None,
         verbose: bool = False,
     ) -> Path:
         """Prefect flow for FITS to Zarr conversion.
@@ -159,6 +180,11 @@ if PREFECT_AVAILABLE:
             Chunk size for l and m spatial dimensions. Defaults to 1024.
         rebuild : bool, optional
             If True, overwrite existing Zarr store. Defaults to False.
+        duplicate_resolver : Callable[[str, float, list[Path]], Path] | None, optional
+            When two FITS files share the same (time, frequency) group, this callback
+            chooses which path to use. If omitted and duplicates exist, conversion
+            raises ``RuntimeError`` at discovery (see ``ConversionConfig`` in
+            ``ovro_lwa_portal.ingest.core``).
         verbose : bool, optional
             Enable verbose logging. Defaults to False.
 
@@ -189,6 +215,7 @@ if PREFECT_AVAILABLE:
             fixed_dir=Path(fixed_dir) if fixed_dir else None,
             chunk_lm=chunk_lm,
             rebuild=rebuild,
+            duplicate_resolver=duplicate_resolver,
             verbose=verbose,
         )
 
@@ -202,7 +229,7 @@ if PREFECT_AVAILABLE:
 
 else:
     # Provide stub implementations when Prefect is not available
-    def fits_to_zarr_flow(*args, **kwargs):  # type: ignore[no-untyped-def]
+    def fits_to_zarr_flow(*args, **kwargs) -> Path:  # type: ignore[no-untyped-def]
         _raise_import_error()
 
 
@@ -213,6 +240,7 @@ def run_conversion_flow(
     fixed_dir: str | Path | None = None,
     chunk_lm: int = 1024,
     rebuild: bool = False,
+    duplicate_resolver: Callable[[str, float, list[Path]], Path] | None = None,
     verbose: bool = False,
 ) -> Path:
     """Run the FITS to Zarr conversion using Prefect orchestration.
@@ -234,6 +262,9 @@ def run_conversion_flow(
         Chunk size for l and m spatial dimensions.
     rebuild : bool, optional
         If True, overwrite existing Zarr store.
+    duplicate_resolver : Callable[[str, float, list[Path]], Path] | None, optional
+        Resolves duplicate FITS files in the same (time, frequency) group; if ``None`` and
+        duplicates exist, conversion raises at discovery time.
     verbose : bool, optional
         Enable verbose logging.
 
@@ -246,6 +277,8 @@ def run_conversion_flow(
     ------
     ImportError
         If Prefect is not installed.
+    RuntimeError
+        If duplicate FITS are found and ``duplicate_resolver`` is not provided.
     """
     if not PREFECT_AVAILABLE:
         msg = (
@@ -263,5 +296,6 @@ def run_conversion_flow(
         fixed_dir=fixed_dir,
         chunk_lm=chunk_lm,
         rebuild=rebuild,
+        duplicate_resolver=duplicate_resolver,
         verbose=verbose,
     )

--- a/tests/test_fits_to_zarr.py
+++ b/tests/test_fits_to_zarr.py
@@ -218,3 +218,32 @@ def test_discover_groups_header_based_frequency_sorting(tmp_path: Path):
 
     freqs = [mod._extract_group_metadata(p)[1] for p in group_files]
     assert freqs == [pytest.approx(4.1e7), pytest.approx(8.2e7)]
+
+
+def test_discover_groups_skips_file_without_time_or_frequency_metadata(tmp_path: Path):
+    """Files with no usable header or filename metadata should be skipped."""
+    mod = _import_module()
+    fits.PrimaryHDU(data=[[1.0]], header=fits.Header({"SIMPLE": True})).writeto(
+        tmp_path / "unparseable_name.fits"
+    )
+
+    groups = mod._discover_groups(tmp_path)
+
+    assert groups == {}
+
+
+def test_discover_groups_filename_fallback_compatibility(tmp_path: Path):
+    """Legacy OVRO-LWA filename pattern should still group when headers are incomplete."""
+    mod = _import_module()
+    fits.PrimaryHDU(data=[[1.0]], header=fits.Header({"SIMPLE": True})).writeto(
+        tmp_path / "20240524_050009_41MHz_averaged_20000_iterations-I-image.fits"
+    )
+    fits.PrimaryHDU(data=[[1.0]], header=fits.Header({"SIMPLE": True})).writeto(
+        tmp_path / "20240524_050009_82MHz_averaged_20000_iterations-I-image.fits"
+    )
+
+    groups = mod._discover_groups(tmp_path)
+
+    assert "20240524_050009" in groups
+    freqs = [mod._extract_group_metadata(p)[1] for p in groups["20240524_050009"]]
+    assert freqs == [pytest.approx(4.1e7), pytest.approx(8.2e7)]

--- a/tests/test_fits_to_zarr.py
+++ b/tests/test_fits_to_zarr.py
@@ -6,6 +6,16 @@ import re
 from pathlib import Path
 
 import pytest
+from astropy.io import fits
+
+
+def _import_module():
+    """Import module under test if optional dependencies are available."""
+    try:
+        from ovro_lwa_portal import fits_to_zarr_xradio
+    except ImportError as e:
+        pytest.skip(f"xradio dependencies not available: {e}")
+    return fits_to_zarr_xradio
 
 
 def test_parse_filename_pattern():
@@ -125,10 +135,66 @@ def test_mhz_from_name_no_match():
 
 def test_module_can_be_imported():
     """Test that the fits_to_zarr_xradio module can be imported."""
-    try:
-        from ovro_lwa_portal import fits_to_zarr_xradio
-        assert hasattr(fits_to_zarr_xradio, "convert_fits_dir_to_zarr")
-        assert hasattr(fits_to_zarr_xradio, "PAT")
-        assert hasattr(fits_to_zarr_xradio, "MHZ_RE")
-    except ImportError as e:
-        pytest.skip(f"xradio dependencies not available: {e}")
+    fits_to_zarr_xradio = _import_module()
+    assert hasattr(fits_to_zarr_xradio, "convert_fits_dir_to_zarr")
+    assert hasattr(fits_to_zarr_xradio, "PAT")
+    assert hasattr(fits_to_zarr_xradio, "MHZ_RE")
+
+
+def test_extract_group_metadata_from_header(tmp_path: Path):
+    """Header metadata should provide both time and frequency."""
+    mod = _import_module()
+    fpath = tmp_path / "arbitrary_name.fits"
+    fits.PrimaryHDU(
+        data=[[1.0]],
+        header=fits.Header({"DATE-OBS": "2024-05-24T05:00:09.0", "RESTFREQ": 4.1e7}),
+    ).writeto(fpath)
+
+    time_key, frequency_hz, notes = mod._extract_group_metadata(fpath)
+
+    assert time_key == "20240524_050009"
+    assert frequency_hz == pytest.approx(4.1e7)
+    assert notes == []
+
+
+def test_extract_group_metadata_fallback_to_filename(tmp_path: Path):
+    """Filename fallback should be used when headers are missing metadata."""
+    mod = _import_module()
+    fpath = tmp_path / "20240524_050009_41MHz_averaged_20000_iterations-I-image.fits"
+    fits.PrimaryHDU(data=[[1.0]], header=fits.Header({"SIMPLE": True})).writeto(fpath)
+
+    time_key, frequency_hz, notes = mod._extract_group_metadata(fpath)
+
+    assert time_key == "20240524_050009"
+    assert frequency_hz == pytest.approx(4.1e7)
+    assert "time-from-filename" in notes
+    assert "frequency-from-filename" in notes
+
+
+def test_discover_groups_duplicate_without_resolver_raises(tmp_path: Path):
+    """Duplicate time/frequency files should raise without a resolver."""
+    mod = _import_module()
+    hdr = fits.Header({"DATE-OBS": "2024-05-24T05:00:09.0", "RESTFREQ": 4.1e7})
+    fits.PrimaryHDU(data=[[1.0]], header=hdr).writeto(tmp_path / "first_name.fits")
+    fits.PrimaryHDU(data=[[1.0]], header=hdr).writeto(tmp_path / "second_name.fits")
+
+    with pytest.raises(RuntimeError, match="Duplicate FITS files detected"):
+        mod._discover_groups(tmp_path)
+
+
+def test_discover_groups_duplicate_with_resolver_selects_one(tmp_path: Path):
+    """Resolver should choose one candidate for duplicate time/frequency groups."""
+    mod = _import_module()
+    hdr = fits.Header({"DATE-OBS": "2024-05-24T05:00:09.0", "RESTFREQ": 4.1e7})
+    f1 = tmp_path / "candidate_a.fits"
+    f2 = tmp_path / "candidate_b.fits"
+    fits.PrimaryHDU(data=[[1.0]], header=hdr).writeto(f1)
+    fits.PrimaryHDU(data=[[1.0]], header=hdr).writeto(f2)
+
+    def choose_second(_time_key: str, _freq_hz: float, candidates: list[Path]) -> Path:
+        return candidates[-1]
+
+    groups = mod._discover_groups(tmp_path, duplicate_resolver=choose_second)
+
+    assert "20240524_050009" in groups
+    assert groups["20240524_050009"] == [f2]

--- a/tests/test_fits_to_zarr.py
+++ b/tests/test_fits_to_zarr.py
@@ -198,3 +198,23 @@ def test_discover_groups_duplicate_with_resolver_selects_one(tmp_path: Path):
 
     assert "20240524_050009" in groups
     assert groups["20240524_050009"] == [f2]
+
+
+def test_discover_groups_header_based_frequency_sorting(tmp_path: Path):
+    """Groups should be deterministically sorted by header frequency."""
+    mod = _import_module()
+    # Write intentionally out-of-order names with opposite order frequencies.
+    fits.PrimaryHDU(
+        data=[[1.0]],
+        header=fits.Header({"DATE-OBS": "2024-05-24T05:00:09.0", "RESTFREQ": 8.2e7}),
+    ).writeto(tmp_path / "aaa_name.fits")
+    fits.PrimaryHDU(
+        data=[[1.0]],
+        header=fits.Header({"DATE-OBS": "2024-05-24T05:00:09.0", "RESTFREQ": 4.1e7}),
+    ).writeto(tmp_path / "zzz_name.fits")
+
+    groups = mod._discover_groups(tmp_path)
+    group_files = groups["20240524_050009"]
+
+    freqs = [mod._extract_group_metadata(p)[1] for p in group_files]
+    assert freqs == [pytest.approx(4.1e7), pytest.approx(8.2e7)]

--- a/tests/test_fits_to_zarr.py
+++ b/tests/test_fits_to_zarr.py
@@ -200,6 +200,28 @@ def test_discover_groups_duplicate_with_resolver_selects_one(tmp_path: Path):
     assert groups["20240524_050009"] == [f2]
 
 
+def test_discover_groups_triple_duplicate_resolver_sees_fresh_candidates(tmp_path: Path):
+    """After resolving two-way duplicate, third file must not reuse stale candidate list."""
+    mod = _import_module()
+    hdr = fits.Header({"DATE-OBS": "2024-05-24T05:00:09.0", "RESTFREQ": 4.1e7})
+    paths = [tmp_path / f"candidate_{i}.fits" for i in range(3)]
+    for p in paths:
+        fits.PrimaryHDU(data=[[1.0]], header=hdr).writeto(p)
+
+    resolver_calls: list[list[Path]] = []
+
+    def record_first(_time_key: str, _freq_hz: float, candidates: list[Path]) -> Path:
+        resolver_calls.append(list(candidates))
+        return candidates[0]
+
+    groups = mod._discover_groups(tmp_path, duplicate_resolver=record_first)
+
+    assert groups["20240524_050009"] == [paths[0]]
+    assert len(resolver_calls) == 2
+    assert resolver_calls[0] == paths[:2]
+    assert resolver_calls[1] == [paths[0], paths[2]]
+
+
 def test_discover_groups_header_based_frequency_sorting(tmp_path: Path):
     """Groups should be deterministically sorted by header frequency."""
     mod = _import_module()


### PR DESCRIPTION
Making the fits to zarr a bit more robust to how fits files are selected and grouped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive duplicate resolver to pick one FITS file when multiple share the same observation time/frequency; progress display pauses during prompting.
  * Conversion now prefers FITS header metadata (filename parsing as fallback); duplicate-resolver option available in conversion workflows.

* **Bug Fixes**
  * Clearer user-facing errors/warnings for missing or fallback metadata.
  * Deterministic grouping/sorting by extracted frequency; files lacking usable metadata are skipped.

* **Tests**
  * Expanded tests for header extraction, fallback behavior, duplicate handling, ordering, and skipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->