### PR TITLE
docs: add Zenodo DOI for v0.1.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,6 +2,9 @@ cff-version: 1.2.0
 title: OVRO-LWA Portal
 message: "If you use this software, please cite it using the metadata from this file."
 type: software
+version: 0.1.0
+date-released: 2026-05-11
+doi: 10.5281/zenodo.20128330
 authors:
   - given-names: Cordero
     family-names: Core

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OVRO-LWA Portal
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.XXXXXXX.svg)](https://doi.org/10.5281/zenodo.XXXXXXX)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20128330.svg)](https://doi.org/10.5281/zenodo.20128330)
 [![PyPI](https://img.shields.io/pypi/v/ovro-lwa-portal)](https://pypi.org/project/ovro-lwa-portal/)
 
 A Python library for radio astronomy data processing and visualization for the


### PR DESCRIPTION
## Summary
- Replace the `zenodo.XXXXXXX` placeholder in the README DOI badge with the real DOI minted by Zenodo for v0.1.0: [10.5281/zenodo.20128330](https://doi.org/10.5281/zenodo.20128330)
- Add `version`, `date-released`, and `doi` fields to `CITATION.cff` so tools like cffconvert include the DOI in generated citations (BibTeX, APA, etc.)

## Test plan
- [ ] README DOI badge renders and links to https://doi.org/10.5281/zenodo.20128330
- [ ] `cffconvert -i CITATION.cff -f bibtex` includes the `doi` field (verified locally)