### PR TITLE
fix: pin prettier v3 and add shared editor config

### DIFF
--- a/.ci-helpers/README.md
+++ b/.ci-helpers/README.md
@@ -30,6 +30,7 @@ The script requires the following environment variables to be set:
 You can provide these environment variables in several ways:
 
 1. **Using a .env file** (recommended for local development):
+
    - Copy `.env.example` to `.env` and fill in your credentials
    - The script will automatically load variables from `.env` in the current
      directory

--- a/.claude/commands/clean-branches.md
+++ b/.claude/commands/clean-branches.md
@@ -8,6 +8,7 @@ omitted, prompt the user.
 ## Instructions
 
 1. Run these commands in parallel to gather branch information:
+
    - `git branch` (local branches)
    - `git branch -r` (remote branches, exclude HEAD)
    - `git branch --merged main` (branches merged into main)
@@ -25,16 +26,19 @@ omitted, prompt the user.
    | **Active**          | Has recent commits and is not merged                              |
 
 3. If `$ARGUMENTS` is empty or unclear:
+
    - Display a summary table of all branches grouped by category with branch
      name, last commit age, and local/remote status
    - Ask the user which categories to clean: merged, stale, orphaned, or all
    - Wait for the user's response before proceeding
 
 4. If `$ARGUMENTS` specifies a category or "all":
+
    - Show the list of branches that will be deleted
    - Ask for confirmation before proceeding
 
 5. Delete branches:
+
    - Local branches: `git branch -d <name>` (safe delete, merged only) or
      `git branch -D <name>` (if user confirms force delete for unmerged)
    - Remote branches: `git push origin --delete <name>`

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -7,6 +7,7 @@ $ARGUMENTS — a description of the issue to create
 ## Instructions
 
 1. Based on `$ARGUMENTS`, determine:
+
    - **Type**: `feat`, `fix`, `refactor`, `docs`, `chore`, `perf`, `ci`,
      `build`, `test`
    - **Scope**: the area of the codebase affected (e.g., `marketing`,

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -3,6 +3,7 @@ Create a pull request for the current branch.
 ## Instructions
 
 1. Run these commands in parallel to understand the current state:
+
    - `git status` (never use `-uall`)
    - `git diff --stat` (check for uncommitted changes)
    - `git branch --show-current` (current branch)
@@ -14,6 +15,7 @@ Create a pull request for the current branch.
 3. If the branch hasn't been pushed, push with `git push -u origin <branch>`.
 
 4. Analyze ALL commits in the branch (not just the latest) to draft:
+
    - **Title**: Use conventional commit format: `type(scope): short description`
      (under 70 chars)
    - **Body**: Structured summary with test plan

--- a/.claude/commands/docs.md
+++ b/.claude/commands/docs.md
@@ -6,6 +6,7 @@ broadly)
 ## Instructions
 
 1. **Gather context** — Run these in parallel to understand what changed:
+
    - `git log --oneline -20` (recent commits)
    - `git diff main...HEAD --stat` (if on a feature branch)
    - `git log --oneline --since="8 hours ago"` (today's work)
@@ -14,6 +15,7 @@ broadly)
 
 2. **Determine scope** — Based on the argument and recent changes, decide which
    docs need writing or updating:
+
    - If argument is a specific topic (e.g., "queues", "auth", "notifications"),
      focus there
    - If argument is a section (e.g., "architecture", "database", "guides"),
@@ -24,18 +26,21 @@ broadly)
 3. **Write documentation** covering these categories as relevant:
 
    ### Technical Details
+
    - What was built, changed, or fixed
    - API contracts, database schema changes, new RPC functions
    - Configuration changes, environment variables, dependencies added
    - Code patterns introduced or modified
 
    ### Technical Architecture
+
    - System design and component relationships
    - Data flow diagrams (use Mermaid syntax)
    - Integration points between services (workers, platform, database)
    - Infrastructure decisions (Cloudflare, Neon, WorkOS, Stripe, etc.)
 
    ### Session Learnings
+
    - Decisions made and their rationale (ADR-style: Decision / Why / Result)
    - Technical issues encountered and how they were resolved
    - Trade-offs considered and which path was chosen
@@ -43,6 +48,7 @@ broadly)
    - Things that didn't work and why
 
 4. **Place documentation correctly:**
+
    - New architecture docs → `docs/architecture/`
    - Database changes → `docs/database/`
    - Frontend changes → `docs/frontend/`

--- a/.claude/commands/merge-pr.md
+++ b/.claude/commands/merge-pr.md
@@ -7,16 +7,19 @@ $ARGUMENTS — PR number or URL (optional, defaults to current branch's PR)
 ## Instructions
 
 1. Determine the PR:
+
    - If `$ARGUMENTS` is provided, use it as the PR number or URL
    - If not, find the PR for the current branch:
      `gh pr view --json number,title,state,headRefName`
 
 2. Check PR status:
+
    - `gh pr view <number> --json state,mergeable,mergeStateStatus,statusCheckRollup,title,headRefName`
    - If checks are failing, warn the user and ask whether to proceed
    - If there are merge conflicts, tell the user and stop
 
 3. Check for local uncommitted changes:
+
    - `git status`
    - If there are unstaged changes, stash them before proceeding: `git stash`
 
@@ -29,6 +32,7 @@ $ARGUMENTS — PR number or URL (optional, defaults to current branch's PR)
    Use `--squash` by default (consistent with this repo's history).
 
 5. Clean up locally:
+
    - Switch to main if not already: `git checkout main`
    - Pull the merged changes: `git pull origin main`
    - Prune stale remote refs: `git fetch --prune`
@@ -36,6 +40,7 @@ $ARGUMENTS — PR number or URL (optional, defaults to current branch's PR)
    - If changes were stashed, restore them: `git stash pop`
 
 6. Verify cleanup:
+
    - `git branch -a | grep <branch-name>` to confirm branch is gone everywhere
 
 7. Confirm: "PR #N merged into main. Branch `<name>` deleted locally and

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -9,6 +9,7 @@ to analyzing changes)
 ## Instructions
 
 1. Determine the version bump:
+
    - If `$ARGUMENTS` specifies `patch`, `minor`, or `major`, use that
    - If not specified, analyze commits since the last tag to determine:
      - `major`: breaking changes (commits with `!` or `BREAKING CHANGE`)
@@ -16,12 +17,14 @@ to analyzing changes)
      - `patch`: fixes, refactors, docs, chores only
 
 2. Get the current version:
+
    - Check `git tag --sort=-v:refname | head -1` for the latest tag
    - If no tags exist, start at `v0.1.0`
 
 3. Calculate the new version following semver.
 
 4. Verify readiness:
+
    - `git status` — must be on `main` with no uncommitted changes
    - `git pull origin main` — must be up to date
    - Warn and stop if not on `main` or if there are uncommitted changes
@@ -29,6 +32,7 @@ to analyzing changes)
 5. Read `CHANGELOG.md` and check that the `[Unreleased]` section has content.
 
 6. Update `CHANGELOG.md`:
+
    - Rename `[Unreleased]` to `[X.Y.Z] -- YYYY-MM-DD` (today's date)
    - Add a new empty `[Unreleased]` section above it
 
@@ -57,6 +61,7 @@ to analyzing changes)
    ```
 
 10. Build plugin zip assets:
+
     - For each directory in `plugins/`, create a zip archive
     - **Zip naming convention:**
       - Default: `plugin_name_MM_DD_YYYY.zip` (snake_case plugin name + date)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,6 +72,7 @@ pixi install
 ### Available Environments
 
 1. **`default`** (features: `pre-commit`, `gh-cli`)
+
    - Standard development environment
    - Radio astronomy packages: astropy, xarray, dask, zarr, xradio,
      python-casacore

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,12 +24,17 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8"
+  # mirrors-prettier is archived; v4.0.0-alpha.8 needs Node 18+ and formats differently
+  # than v3. Pin prettier@3.x via a local hook so CI and editors stay aligned.
+  - repo: local
     hooks:
       - id: prettier
+        name: prettier
+        entry: prettier --write --ignore-unknown
+        language: node
         types_or: [yaml, markdown, html, css, scss, javascript, json]
-        args: [--prose-wrap=always]
+        additional_dependencies:
+          - "prettier@3.5.3"
 
   - repo: local
     hooks:

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,3 @@
+# Shared with the pre-commit prettier hook (.pre-commit-config.yaml).
+# Install the Prettier VS Code/Cursor extension for format-on-save in editors.
+proseWrap: always

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,16 @@
 {
   "python.defaultInterpreterPath": "${workspaceFolder}/.pixi/envs/default/bin/python",
   "python-envs.defaultEnvManager": "ms-python.python:system",
-  "kiroAgent.configureMCP": "Disabled"
+  "kiroAgent.configureMCP": "Disabled",
+  "editor.formatOnSave": true,
+  "prettier.requireConfig": true,
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ command is idempotent and safe to run multiple times.
 ### Available Environments
 
 1. **`default`** (features: `pre-commit`, `gh-cli`)
+
    - Standard development environment
    - Radio astronomy packages: astropy, xarray, dask, zarr, netcdf4, numcodecs
    - OVRO-LWA specific: xradio, python-casacore
@@ -324,12 +325,14 @@ capabilities:
 ### Core Architecture
 
 1. **Core Module** (`ingest/core.py`):
+
    - `ConversionConfig`: Configuration dataclass for conversion parameters
    - `FITSToZarrConverter`: Main orchestration class (framework-independent)
    - `FileLock`: Cross-platform file locking using portalocker
    - `ProgressCallback`: Protocol for progress reporting
 
 2. **CLI Module** (`ingest/cli.py`):
+
    - Typer-based CLI with rich progress bars
    - Logging configuration (debug, info, warning, error levels)
    - Error handling with actionable messages
@@ -437,7 +440,7 @@ Canonical helpers in `src/ovro_lwa_portal/accessor.py`:
 | `_has_per_time_wcs_header_str(ds)`          | True when `wcs_header_str` is indexed by `time` (1-D or `(time, frequency)`)                                   |
 | `_read_wcs_header_str(ds, time_idx=…)`      | FITS header string for one time index                                                                          |
 | `strip_redundant_fits_wcs_header_attrs(ds)` | Drop static `fits_wcs_header` attrs when `wcs_header_str` is canonical (used by `open_dataset` and Zarr write) |
-| `RadportAccessor._get_wcs(time_idx=…)`      | Astropy WCS for pixel↔sky mapping                                                                              |
+| `RadportAccessor._get_wcs(time_idx=…)`      | Astropy WCS for pixel↔sky mapping                                                                             |
 | `pixel_to_coords` / `coords_to_pixel`       | Must pass `time_idx` when per-time WCS exists                                                                  |
 
 **Strict rules (do not break these):**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ Request:
 - It may be helpful to review
   [this tutorial](https://www.dataschool.io/how-to-contribute-on-github/) on how
   to contribute to open source projects. A typical task workflow is:
+
   - [Fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the
     code repository specified in the task and
     [clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -675,16 +675,19 @@ required** for the initial PR but could be added later.
 
 1. **`spectral_index(l, m, ...)`** - Compute spectral index (power-law slope) at
    a location
+
    - Returns α where S ∝ ν^α, computed as log(S₂/S₁) / log(ν₂/ν₁)
    - Supports frequency selection via MHz or index
 
 2. **`spectral_index_map(...)`** - Compute spectral index map across the full
    image
+
    - Returns DataArray with dims (l, m)
    - Includes frequency metadata in attrs
 
 3. **`integrated_flux(l, m, ...)`** - Compute integrated flux density over
    frequency band
+
    - Uses trapezoidal integration (numpy.trapezoid)
    - Returns flux in Jy·Hz
 

--- a/docs/user-guide/fits-to-zarr.md
+++ b/docs/user-guide/fits-to-zarr.md
@@ -166,6 +166,7 @@ region = ds.sel(ra=slice(10, 20), dec=slice(-5, 5))
 ## Best Practices
 
 1. **Chunk Size**: Choose chunk sizes that match your access patterns
+
    - For time series analysis: larger time chunks
    - For spatial analysis: larger l/m chunks
 

--- a/docs/user-guide/zarr-optimization/chunking-benchmarking.md
+++ b/docs/user-guide/zarr-optimization/chunking-benchmarking.md
@@ -178,12 +178,14 @@ reproducible results:
 1. **Define 3–5 representative access patterns** matching real user workflows.
    Use the recipes from [Read-Time Optimization](chunking-read-optimization.md)
    as templates:
+
    - Recipe A: Full spatial images (snapshot analysis)
    - Recipe B: Time series at a point
    - Recipe C: Spectral analysis
    - Recipe D: Full dataset batch processing
 
 2. **Create a controlled environment** to minimize external variability:
+
    - Consistent network: Use the same network connection for all runs
    - No background jobs: Close applications that may compete for bandwidth or
      CPU
@@ -191,6 +193,7 @@ reproducible results:
      rather than shared/spot instances
 
 3. **Distinguish warm cache vs. cold cache measurements:**
+
    - **Warm cache:** Data is already in OS page cache or fsspec cache. Measures
      compute and memory performance without I/O latency. To warm cache: run the
      operation once, then measure subsequent runs.

--- a/docs/user-guide/zarr-optimization/chunking-cloud-storage.md
+++ b/docs/user-guide/zarr-optimization/chunking-cloud-storage.md
@@ -862,6 +862,7 @@ NoSuchBucket: The specified bucket does not exist
    ```
 
 2. **Wrong endpoint** — Bucket exists on different OSN pod or AWS region:
+
    - OSN buckets are pod-specific (uma1 vs caltech1)
    - AWS buckets are region-specific (us-east-1 vs us-west-2)
 

--- a/research-zarr-chunk-optimization.md
+++ b/research-zarr-chunk-optimization.md
@@ -366,6 +366,7 @@ ds = ovro_lwa_portal.open_dataset(
 ## Technical Decisions
 
 - **Decision:** Fixed `chunk_lm=1024` default for spatial dimensions only
+
   - **Rationale:** Balances spatial tile size with memory; 1024x1024 float32 = 4
     MB per tile
   - **Trade-offs:** Good for full-image spatial access; suboptimal for
@@ -373,11 +374,13 @@ ds = ovro_lwa_portal.open_dataset(
     pixel)
 
 - **Decision:** No explicit compression configuration
+
   - **Rationale:** Relies on xradio `write_image()` defaults
   - **Trade-offs:** Simplifies ingest code but may leave performance on the
     table; users cannot currently control compression without modifying code
 
 - **Decision:** Zarr v2 pinned (no sharding)
+
   - **Rationale:** Required by xradio compatibility (`xradio/issues/355`)
   - **Trade-offs:** Each chunk = one object; no sub-chunk access. Must balance
     chunk count vs. chunk size without sharding.
@@ -432,6 +435,7 @@ ds = ovro_lwa_portal.open_dataset(
 ## References
 
 - Files analyzed: 8 total files
+
   - `src/ovro_lwa_portal/io.py` -- open_dataset(), resolve_source(),
     DataSourceError
   - `src/ovro_lwa_portal/fits_to_zarr_xradio.py` -- FITS-to-Zarr ingest with

--- a/specs/001-build-an-ingest/IMPLEMENTATION_STATUS.md
+++ b/specs/001-build-an-ingest/IMPLEMENTATION_STATUS.md
@@ -366,11 +366,13 @@ task count.
 ### High Priority (User-Impacting)
 
 1. **No Resume Capability** (NFR-002 violation)
+
    - **Impact**: Long-running conversions cannot be resumed after interruption
    - **Workaround**: Use append mode and track completed time steps manually
    - **Future Work**: Implement `PipelineState` with JSON persistence
 
 2. **Limited Grid Validation** (FR-009 partially met)
+
    - **Impact**: Grid mismatches produce less actionable error messages
    - **Workaround**: Pre-validate FITS files manually
    - **Future Work**: Add `SpatialGrid` model with checksum validation
@@ -383,11 +385,13 @@ task count.
 ### Medium Priority (Developer Experience)
 
 4. **No Modular Discovery/Validation**
+
    - **Impact**: Cannot reuse discovery logic independently
    - **Workaround**: Import from `fits_to_zarr_xradio.py`
    - **Future Work**: Extract to `discovery.py` and `validation.py`
 
 5. **Limited Test Coverage**
+
    - **Impact**: Integration tests incomplete
    - **Workaround**: Manual testing
    - **Future Work**: Complete integration test suite from tasks.md
@@ -400,6 +404,7 @@ task count.
 ### Low Priority (Nice to Have)
 
 7. **Basic Logging Configuration**
+
    - **Impact**: No structured logging or detailed metrics
    - **Workaround**: Increase log level to debug
    - **Future Work**: Implement comprehensive logging from FR-028/029
@@ -525,12 +530,14 @@ features deferred for future iterations.
 ### For Future Development
 
 1. **Phase 2 Features** (based on user demand):
+
    - Resume/rebuild capability (NFR-002)
    - Comprehensive grid validation (FR-009)
    - Detailed progress reporting (FR-029)
    - Enhanced error diagnostics
 
 2. **Refactoring Opportunities**:
+
    - Extract discovery module
    - Extract validation module
    - Add Pydantic models for public API

--- a/specs/001-build-an-ingest/plan.md
+++ b/specs/001-build-an-ingest/plan.md
@@ -366,6 +366,7 @@ with:
 **Configuration Models** (using pydantic-settings):
 
 1. **ConversionOptions** (frozen BaseSettings):
+
    - input_dir, output_dir, zarr_name, fixed_dir, chunk_lm, rebuild, use_prefect
    - Loaded from CLI args, environment variables, or config files
    - Validators: directories exist/writable, chunk size positive
@@ -409,37 +410,44 @@ _This section describes what the /tasks command will do - DO NOT execute during
 **Approach**: **TDD Bottom-Up with Pydantic-First**
 
 1. **Layer 1: Pydantic Models** (Tests → Implementation)
+
    - Create Pydantic model factories for testing (pytest fixtures)
    - Write validation tests for each model
    - Implement Pydantic models with Field validators
    - Test serialization/deserialization
 
 2. **Layer 2: Pydantic Settings** (Tests → Implementation)
+
    - Test configuration loading from env vars
    - Test configuration validation
    - Implement BaseSettings classes
    - Test defaults and overrides
 
 3. **Layer 3: Core Utilities** (Tests → Implementation)
+
    - File locking tests
    - State management tests (Pydantic model persistence)
    - Logging configuration tests
 
 4. **Layer 4: Conversion Logic** (Tests → Implementation → Refactor)
+
    - Extract and test each function from existing fits_to_zarr_xradio.py
    - Update signatures to use Pydantic models
    - Maintain backward compatibility wrapper
 
 5. **Layer 5: Discovery & Orchestration** (Tests → Implementation)
+
    - Discovery functions with Pydantic model returns
    - High-level orchestration with validated inputs
 
 6. **Layer 6: CLI Interface** (Tests → Implementation)
+
    - Typer CLI with Pydantic integration (typer.Option with Pydantic types)
    - Interactive prompts
    - Error formatting with Pydantic messages
 
 7. **Layer 7: Optional Prefect Layer** (Tests → Implementation)
+
    - Prefect flows with Pydantic model passing
 
 8. **Layer 8: Integration & Acceptance** (End-to-End)


### PR DESCRIPTION
## Summary

- Replace `mirrors-prettier` **v4.0.0-alpha.8** with a local pre-commit hook on **prettier@3.5.3** (stable, works on Node 14+, no alpha format drift).
- Add **`.prettierrc.yaml`** (`proseWrap: always`) so the hook and editors use the same rules.
- Update **`.vscode/settings.json`** to format markdown/yaml/json with Prettier on save when the config file is present.

Prettier v4 alpha was auto-bumped by pre-commit-ci (#59). It crashes on older Node (`EventTarget is not defined`) and repeatedly reformatted `AGENTS.md` on CI because editor saves did not match hook args. This PR normalizes formatting once under v3.5.3.

## Test plan

- [x] `pixi run pre-commit-all` passes (two consecutive runs)
- [ ] After merge, rebase `cjl/dev` and run `pixi run pre-commit-all` before the next push
- [ ] Install the [Prettier VS Code extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and confirm markdown save matches hook output